### PR TITLE
Setup automatic version upgrades of pkglist

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - .github/workflows/versions.yml
       - provision/pkglist
-      - tools/upgrade.bash
+      - tools/apt.bash
 
 jobs:
   apt-get:
@@ -18,7 +18,7 @@ jobs:
       - name: Review and upgrade the dependencies
         uses: docker://cardboardci/ci-core:privileged
         with:
-          args: "tools/upgrade.bash"
+          args: "tools/apt.bash"
       - name: Commit the dependency changes
         uses: cardboardci/github-actions/auto-commit@master
         env:

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -1,0 +1,28 @@
+name: Check for dependencies
+
+on:
+  schedule:
+  - cron: "0 8 * * 3"
+
+  push:
+    paths:
+      - .github/workflows/versions.yml
+      - provision/pkglist
+      - tools/upgrade.bash
+
+jobs:
+  apt-get:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Review and upgrade the dependencies
+        uses: docker://cardboardci/ci-core:privileged
+        with:
+          args: "tools/upgrade.bash"
+      - name: Commit the dependency changes
+        uses: cardboardci/github-actions/auto-commit@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: '/pkglist'
+          MESSAGE: 'Upgrade packages to latest apt-get dependencies'
+          PULL_REQUEST_TITLE: 'Bump image dependencies to latest'

--- a/tools/apt.bash
+++ b/tools/apt.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Update package status
+apt-get update
+
+# Emit the current versions
+echo "Current versions"
+cat provision/pkglist
+
+mv provision/pkglist provision/pkglist.bak
+touch provision/pkglist
+while read line; do
+    echo "Working with ${line}"
+    input=(${line//=/ })
+    echo "Determining version for ${input}"
+    version=$(apt-cache policy ${input} | grep 'Candidate: ' | awk -F"[ ',]+" '/Candidate:/{print $3}')
+    echo "Found version as ${version}"
+    echo "${input}=${version}" >> provision/pkglist
+done <provision/pkglist.bak
+
+#
+rm provision/pkglist.bak
+cat provision/pkglist


### PR DESCRIPTION
Setup the script responsible for upgrading the apt dependencies defined in the provision/pkglist file. This script will run on a weekly frequency, and check to see if any dependencies are available for the base image.

For now the base image is hard-coded to latest, but will later be refactored to use docker run on the base machine (using the base image).